### PR TITLE
Align `Status Code` output with `Response Body` 

### DIFF
--- a/python.mustache
+++ b/python.mustache
@@ -50,7 +50,7 @@ def send_request():
             data = json.dumps({{{body.json_body_object}}})
             {{/body.has_json_body}}
         )
-        print('Response HTTP Status Code : {status_code}'.format(status_code=r.status_code))
+        print('Response HTTP Status Code   : {status_code}'.format(status_code=r.status_code))
         print('Response HTTP Response Body : {content}'.format(content=r.content))
     except requests.exceptions.RequestException as e:
         print('HTTP Request failed')


### PR DESCRIPTION
I'm a big fan of keeping data aligned for outputs, I created this PR in order to align the `HTTP Status Code` line with `HTTP Response Body`. Tried it out, and liked the results!

```python
send_request()
Response HTTP Status Code   : 200
Response HTTP Response Body : b'{\n  "sys_time": 1.760346,\n  "user_time": 1.637324\n}'
```